### PR TITLE
Fix game-of-life rect-stepper

### DIFF
--- a/ch03-game-of-life/src/com/clojurebook/collections/life.clj
+++ b/ch03-game-of-life/src/com/clojurebook/collections/life.clj
@@ -142,7 +142,7 @@
    board of specified size."
   [w h]
   (stepper #(filter (fn [[i j]] (and (< -1 i w) (< -1 j h))) 
-                    (neighbours %)) #{2 3} #{3}))
+                    (neighbours %)) #{3} #{2 3}))
 
 (defn draw
   [w h step cells]


### PR DESCRIPTION
The birth and survive values in rect-stepper are switched. This fixes it :-)
