### PR TITLE
compare-magnitude doesn't produce correct pred used by comparator

### DIFF
--- a/ch03-collections-repl-interactions.clj
+++ b/ch03-collections-repl-interactions.clj
@@ -575,7 +575,7 @@ sm
 ;-----
 (defn compare-magnitude
   [a b]
-  (- (magnitude a) (magnitude b)))
+  (< (magnitude a) (magnitude b)))
 
 ((comparator compare-magnitude) 10 10000)
 ;= -1


### PR DESCRIPTION
`(comparator compare-magnitude)` will always return -1. Should change "-" to "<" in `compare-magnitude` to produce correct boolean pred for `comparator` instead of numeric result (which always evaluate to true).
